### PR TITLE
Update StackSizeController.json

### DIFF
--- a/ModConfigFiles/StackSizeController.json
+++ b/ModConfigFiles/StackSizeController.json
@@ -62,7 +62,7 @@
   "Cooked Pork": 100,
   "Cooked Wolf Meat": 100,
   "Corn Seed": 50,
-  "Crude Oil": 500,
+  "Crude Oil": 2500,
   "Door Key": 1,
   "Double Sign Post": 1,
   "Empty Can Of Beans": 1,


### PR DESCRIPTION
Increasing stack size for crude oil to 2500 to match the stack size of low grade fuel